### PR TITLE
Fix: Add quote_keys=True to json5.dumps to prevent breaking Waybar config

### DIFF
--- a/waybar_configurator.py
+++ b/waybar_configurator.py
@@ -724,7 +724,7 @@ class App(Adw.Application):
         cfg["modules-left"] = left
         cfg["modules-center"] = center
         cfg["modules-right"] = right
-        write_text(CONFIG_JSONC, json5.dumps(cfg, indent=2))
+        write_text(CONFIG_JSONC, json5.dumps(cfg, indent=2, quote_keys=True))
         self.cfg = cfg
         self.cfg_text = read_text(CONFIG_JSONC)
         self.refresh_modules_section()
@@ -1058,7 +1058,7 @@ class App(Adw.Application):
             return "[\n" + (",\n".join(lines) + ("\n" if lines else "")) + "  ]"
 
         cfg = read_jsonc(CONFIG_JSONC)
-        dumped = json5.dumps(cfg, indent=2)
+        dumped = json5.dumps(cfg, indent=2, quote_keys=True)
         left_txt   = collect_zone_text("modules-left")
         center_txt = collect_zone_text("modules-center")
         right_txt  = collect_zone_text("modules-right")


### PR DESCRIPTION
This is a fix for #1 caused by the json5.dumps() function optimizing the output by removing quotation marks from any JSON keys that are simple words (e.g, it writes `layer: "top"` instead of `"layer": "top"`).

I have added the `quote_keys=True` argument to both `json5.dumps()` calls (in `on_save_clicked` and `apply_modules_from_editor`.